### PR TITLE
[runner] Use 644 permission for parameters.conf

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -365,10 +365,10 @@ RestartSec=%s
 		return aoserrors.Wrap(err)
 	}
 
-	if err := os.WriteFile(
+	if err := os.WriteFile( // nolint:gosec // To fix systemd warning, file parameters.conf should be 644
 		filepath.Join(parametersDir, parametersFileName),
 		[]byte(fmt.Sprintf(parametersFormat, params.StartInterval, params.StartBurst, params.RestartInterval)),
-		0o600); err != nil {
+		0o644); err != nil {
 		return aoserrors.Wrap(err)
 	}
 


### PR DESCRIPTION
To fix systemd warning file parameters.conf is marked world-inaccessible.
This has no effect as configuration data is accessible via APIs without
restrictions. Proceeding anyway.