### PR TITLE
[launcher] Support env var with more than one `=` symbol

### DIFF
--- a/launcher/spec.go
+++ b/launcher/spec.go
@@ -184,15 +184,12 @@ func (spec *runtimeSpec) addRlimit(rlimit runtimespec.POSIXRlimit) {
 }
 
 func getEnvVarName(envVar string) string {
-	const numEnvFields = 2
-
-	fields := strings.SplitN(envVar, "=", numEnvFields)
-
-	if len(fields) < numEnvFields {
+	lastPosition := strings.LastIndex(envVar, "=")
+	if lastPosition < 0 {
 		return strings.TrimSpace(envVar)
 	}
 
-	return strings.TrimSpace(fields[0])
+	return strings.TrimSpace(envVar[:lastPosition])
 }
 
 func (spec *runtimeSpec) mergeEnv(newVars []string) {


### PR DESCRIPTION
Signed-off-by: Yevgen Abramov <Yevgen_Abramov@epam.com>