### PR TITLE
[launcher] Set service CPU quota according to system CPU counts

### DIFF
--- a/launcher/launcher_test.go
+++ b/launcher/launcher_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/google/uuid"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/shirou/gopsutil/cpu"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/aoscloud/aos_servicemanager/config"
@@ -815,8 +816,13 @@ func TestRuntimeSpec(t *testing.T) {
 		t.Errorf("Wrong CPU period value: %d", *runtimeSpec.Linux.Resources.CPU.Period)
 	}
 
+	cpuCount, err := cpu.Counts(true)
+	if err != nil {
+		t.Fatalf("Can't get cpu count: %v", err)
+	}
+
 	if *runtimeSpec.Linux.Resources.CPU.Quota !=
-		int64(*serviceConfig.Quotas.CPULimit*(*runtimeSpec.Linux.Resources.CPU.Period)/100) {
+		int64(*serviceConfig.Quotas.CPULimit*(*runtimeSpec.Linux.Resources.CPU.Period)*uint64(cpuCount)/100) {
 		t.Errorf("Wrong CPU quota value: %d", *runtimeSpec.Linux.Resources.CPU.Quota)
 	}
 

--- a/launcher/spec.go
+++ b/launcher/spec.go
@@ -35,6 +35,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/devices"
 	"github.com/opencontainers/runc/libcontainer/specconv"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/shirou/gopsutil/cpu"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/aoscloud/aos_servicemanager/servicemanager"
@@ -110,7 +111,14 @@ func (spec *runtimeSpec) setCPULimit(cpuLimit uint64) {
 		spec.ociSpec.Linux.Resources.CPU = &runtimespec.LinuxCPU{}
 	}
 
-	cpuQuota := int64((defaultCPUPeriod * (cpuLimit)) / 100) //nolint:gomnd // Translate to percents
+	cpuCount, err := cpu.Counts(true)
+	if err != nil {
+		log.Errorf("Can't get cpu count: %v", err)
+
+		cpuCount = 1
+	}
+
+	cpuQuota := int64((defaultCPUPeriod * (cpuLimit) * uint64(cpuCount)) / 100) //nolint:gomnd // Translate to percents
 	cpuPeriod := defaultCPUPeriod
 
 	spec.ociSpec.Linux.Resources.CPU.Period = &cpuPeriod


### PR DESCRIPTION
We should take into account system CPU counts when setting quota for service.